### PR TITLE
feat: implement Display trait for Status and Card

### DIFF
--- a/src/board/card.rs
+++ b/src/board/card.rs
@@ -51,6 +51,25 @@ impl Card {
     }
 }
 
+impl std::fmt::Display for Card {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let status = self.status.to_string();
+        let title = &self.title;
+        let date = self
+            .date
+            .as_ref()
+            .map(|d| format!(" @{{{}}}", d))
+            .unwrap_or_default();
+        let time = self
+            .time
+            .as_ref()
+            .map(|t| format!(" @@{{{}}}", t))
+            .unwrap_or_default();
+
+        write!(f, "- [{status}] {title}{date}{time}")
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct CardBuilder {
     column: Option<String>,

--- a/src/board/status.rs
+++ b/src/board/status.rs
@@ -5,12 +5,13 @@ pub enum Status {
     Incomplete,
 }
 
-impl Status {
-    pub fn to_string(&self) -> String {
-        match self {
+impl std::fmt::Display for Status {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let string = match self {
             Status::Done => "x".to_string(),
             Status::Incomplete => " ".to_string(),
-        }
+        };
+        write!(f, "{string}")
     }
 }
 


### PR DESCRIPTION
### Pull Request Description

This pull request introduces the implementation of the `Display` trait for both the `Status` enum and theCard` struct.

#### Changes Made:
- Refactored the `Status` enum to provide a custom string representation by implementing the `Display` trait.
- Updated the `Card` struct to also implement the `Display` trait, allowing for a more user-friendly output when instances of `Card` are printed.